### PR TITLE
Changing package from docker-machine to dockertoolbox and revising virtualbox version

### DIFF
--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -49,6 +49,11 @@ GITHUBTARBALL
     usbethdriver (1.0.0)
 
 GITHUBTARBALL
+  remote: barklyprotects/puppet-virtualbox
+  specs:
+    virtualbox (1.0.14)
+
+GITHUBTARBALL
   remote: barklyprotects/s3bucket
   specs:
     s3bucket (1.0.8)
@@ -375,6 +380,7 @@ DEPENDENCIES
   tmux (= 1.0.2)
   tunnelblick (= 1.0.8)
   usbethdriver (= 1.0.0)
+  virtualbox (= 1.0.14)
   vmware_fusion (= 1.2.0)
   wget (= 1.0.0)
   xquartz (= 1.2.1)

--- a/modules/cylent/manifests/apps/docker_machine.pp
+++ b/modules/cylent/manifests/apps/docker_machine.pp
@@ -8,7 +8,7 @@ class cylent::apps::docker_machine (
 
   notify { 'class cylent::apps::docker_machine declared': }
 
-  package { 'docker-machine':
+  package { 'dockertoolbox':
     ensure => present,
     provider => 'brewcask'
   }
@@ -16,7 +16,7 @@ class cylent::apps::docker_machine (
   exec { 'create machine':
     command => "/usr/local/bin/docker-machine --native-ssh create $machine_name --driver $docker_machine_driver --${docker_machine_driver}-boot2docker-url $boot2docker_url",
     unless => "/usr/local/bin/docker-machine inspect $machine_name",
-    require => Package['docker-machine']
+    require => Package['dockertoolbox']
   }
 
   exec { 'start machine':


### PR DESCRIPTION
brew docker-machine package is no longer available. It is now available under dockertoolbox. Adding the new virtualbox version.
