### PR TITLE
Fix Boxen Intellij and git-crypt Errors

### DIFF
--- a/modules/cylent/manifests/apps/default_apps.pp
+++ b/modules/cylent/manifests/apps/default_apps.pp
@@ -52,7 +52,7 @@ class cylent::apps::default_apps {
     ]:
   }
   ->
-  file {'/bin/git-crypt':
+  file {'/usr/local/bin/git-crypt':
     ensure => link,
     target => "/opt/boxen/homebrew/bin/git-crypt"
   }

--- a/modules/cylent/manifests/apps/default_apps.pp
+++ b/modules/cylent/manifests/apps/default_apps.pp
@@ -21,7 +21,7 @@ class cylent::apps::default_apps {
 
   class {'intellij':
     edition => 'ultimate',
-    version => '14.1.4'
+    version => '15.0.3'
   }
 
   # Homebrew Packages

--- a/modules/cylent/manifests/apps/default_apps.pp
+++ b/modules/cylent/manifests/apps/default_apps.pp
@@ -51,9 +51,4 @@ class cylent::apps::default_apps {
       'go',
     ]:
   }
-  ->
-  file {'/usr/local/bin/git-crypt':
-    ensure => link,
-    target => "/opt/boxen/homebrew/bin/git-crypt"
-  }
 }


### PR DESCRIPTION
In terms of the Intellij update, the problem was simply that the '14.1.4' is not a supported version to download (for whatever reason). Any versions, in addition to the current '15.0.3' version , on this site should be okay to use:

https://confluence.jetbrains.com/display/IntelliJIDEA/Previous+IntelliJ+IDEA+Releases

If there is a reason not to use the most recent version of Intellij, choose a version from the above site.
