### PR TITLE
remove node 0.6

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -66,7 +66,6 @@ node default {
   }
 
   # node versions
-  nodejs::version { '0.6': }
   nodejs::version { '0.8': }
   nodejs::version { '0.10': }
   nodejs::version { '0.12': }


### PR DESCRIPTION
- doesn't build on 10.11.5
- isn't supported by nodejs anymore
- we don't need it
