### PR TITLE
messin with dnsmasq

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,7 +38,7 @@ github "module_data", "0.0.4", :repo => "ripienaar/puppet-module-data"
 # some/most of these if you want, but it's not recommended.
 
 github "brewcask",    "0.0.7"
-github "dnsmasq",     "2.0.1"
+github "dnsmasq",     "2.0.9", :repo => "bd808/puppet-dnsmasq"
 github "foreman",     "1.2.0"
 github "gcc",         "3.0.2"
 github "git",         "2.9.0"

--- a/modules/people/manifests/sccsas.pp
+++ b/modules/people/manifests/sccsas.pp
@@ -20,6 +20,11 @@ class people::sccsas {
   include osx::finder::empty_trash_securely
   include osx::finder::show_hidden_files
 
+  include dnsmasq
+  dnsmasq::address { 'angalia-web-portal-functional-tests':
+    ipaddr => '172.16.132.128'
+  }
+
   class { 'osx::global::natural_mouse_scrolling':
     enabled => false
   }


### PR DESCRIPTION
The purpose of this PR is to allow devs to run the portal functional tests within the IDE.
The customized version of puppet-dnsmasq allows one to map host to ip within their .pp file.
see https://github.com/bd808/puppet-dnsmasq
